### PR TITLE
Fixed random deadlocks

### DIFF
--- a/lib/rack-affiliates.rb
+++ b/lib/rack-affiliates.rb
@@ -35,16 +35,14 @@ module Rack
         env['affiliate.from'] = from
         env['affiliate.time'] = time
       end
-      
+
       status, headers, body = @app.call(env)
 
-      response = Rack::Response.new body, status, headers
-
       if tag != cookie_tag
-        bake_cookies(response, tag, from, time)
+        bake_cookies(headers, tag, from, time)
       end
 
-      response.finish
+      [status, headers, body]
     end
 
     def affiliate_info(req)
@@ -60,14 +58,14 @@ module Rack
     end
 
     protected
-    def bake_cookies(res, tag, from, time)
+    def bake_cookies(headers, tag, from, time)
       expires = Time.now + @cookie_ttl
       { COOKIE_TAG => tag, 
         COOKIE_FROM => from, 
         COOKIE_TIME => time }.each do |key, value|
           cookie_hash = {:value => value, :expires => expires}
           cookie_hash[:domain] = @cookie_domain if @cookie_domain
-          res.set_cookie(key, cookie_hash)
+          Rack::Utils.set_cookie_header!(headers, key, cookie_hash)
       end 
     end
   end


### PR DESCRIPTION
This commit fixes the random deadlocks and internal server errors that were showing up when running Rails 3.2 on Ruby 1.9 or greater. The cookie is now getting set directly on the response headers instead of on a new Rack::Response object (which isn't thread safe). The tests are still passing 100%.
